### PR TITLE
Support for custom fields

### DIFF
--- a/mockups/factory.py
+++ b/mockups/factory.py
@@ -85,8 +85,12 @@ class Factory(object):
             return generators.ChoiceFieldGenerator(field)
         elif field.default is not models.NOT_PROVIDED:
             return None # bail out
-        elif field.__class__ in self.fieldclass_to_generator:
-            obj = self.fieldclass_to_generator.get(field.__class__)
+        # check if any of bases exests in self.fieldclass_to_generator
+        elif (set(field.__class__.__mro__).
+              intersection(self.fieldclass_to_generator)):
+            for cls in field.__class__.__mro__:
+                if cls in self.fieldclass_to_generator:
+                    obj = self.fieldclass_to_generator.get(cls)
         else:
             return None # No matching generator found
 


### PR DESCRIPTION
Fixes search for generator by field class. Now search is performed not only in field class, but also in all bases of field class.

This solves problem, with custom fields, that extends an field added to DEFAULT_FIELDCLASS_TO_GENERATOR.
